### PR TITLE
Corrected how responses are processed and add the test to it

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule AlchemetricsTesla.Mixfile do
       {:alchemetrics, "0.5.1"},
       {:tesla, "~> 1.0.0"},
       {:mock, "~> 0.3.1", only: :test},
-      {:excoveralls, "~> 0.7.4", only: :test},
+      {:excoveralls, "~> 0.7", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev},
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -39,7 +39,7 @@ defmodule AlchemetricsTesla.Mixfile do
       {:alchemetrics, "0.5.1"},
       {:tesla, "~> 1.0.0"},
       {:mock, "~> 0.3.1", only: :test},
-      {:excoveralls, "~> 0.7", only: :test},
+      {:excoveralls, "~> 0.7.4", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev},
     ]
   end

--- a/test/support/tesla_client.ex
+++ b/test/support/tesla_client.ex
@@ -5,7 +5,7 @@ defmodule Support.TeslaClient do
   adapter(fn env ->
     cond do
       String.match?(env.url, ~r{user/pets}) -> {:ok, %{env | status: 200, body: "pets"}}
-      String.match?(env.url, ~r{user/error}) -> {:error, %Tesla.Error{reason: :generic_error}}
+      String.match?(env.url, ~r{user/error}) -> {:error, :generic_error}
     end
   end)
 end

--- a/test/tesla/middleware/alchemetrics_test.exs
+++ b/test/tesla/middleware/alchemetrics_test.exs
@@ -35,11 +35,26 @@ defmodule Tesla.Middleware.AlchemetricsTest do
       request_details: %{
         service: "Support.TeslaClient",
         method: :get,
-        protocol: :"https",
+        protocol: :https,
         domain: :"mypets.com",
         port: :"443",
       },
     ], :_)
+  end
+
+  test "report response in error" do
+    TeslaClient.get("https://mypets.com/user/error")
+    assert called Alchemetrics.increment([
+      type: "external_call.count",
+      request_details: %{
+        domain: :"mypets.com",
+        method: :get,
+        port: :"443",
+        protocol: :https,
+        service: "Support.TeslaClient"
+      },
+      response_details: %{status_code: :generic_error, status_code_group: :error}
+    ])
   end
 
   test "report response counting" do
@@ -49,7 +64,7 @@ defmodule Tesla.Middleware.AlchemetricsTest do
       request_details: %{
         service: "Support.TeslaClient",
         method: :get,
-        protocol: :"http",
+        protocol: :http,
         domain: :"mypets.com",
         port: :"80",
       },
@@ -68,7 +83,7 @@ defmodule Tesla.Middleware.AlchemetricsTest do
       request_details: %{
         service: "Support.TeslaClient",
         method: :get,
-        protocol: :"http",
+        protocol: :http,
         domain: :"mypets.com",
         port: :"80",
       },
@@ -76,43 +91,6 @@ defmodule Tesla.Middleware.AlchemetricsTest do
         status_code_group: :"2xx",
         status_code: :"200",
       },
-    ])
-  end
-
-  test "report exception counting" do
-    {:error, %Tesla.Error{}} = TeslaClient.get("http://mypets.com/user/error?specie=dog")
-    assert called Alchemetrics.increment([
-      type: "external_call.count",
-      request_details: %{
-        service: "Support.TeslaClient",
-        method: :get,
-        protocol: :http,
-        domain: :"mypets.com",
-        port: :"80",
-      },
-      response_details: %{
-        status_code_group: :error,
-        status_code: :generic_error,
-      }
-    ])
-  end
-
-  test "report exception counting with custom metric route name" do
-    {:error, %Tesla.Error{}} = TeslaClient.delete("http://mypets.com/user/error?specie=dog", opts: [alchemetrics_metadata: %{route_name: "delete-pet"}])
-    assert called Alchemetrics.increment([
-      extra: %{ route_name: "delete-pet" },
-      type: "external_call.count",
-      request_details: %{
-        service: "Support.TeslaClient",
-        method: :delete,
-        protocol: :http,
-        domain: :"mypets.com",
-        port: :"80",
-      },
-      response_details: %{
-        status_code_group: :error,
-        status_code: :generic_error,
-      }
     ])
   end
 


### PR DESCRIPTION
The old version of Tesla library, before the update, send Tesla.Env or Tesla.Error after the connections, after this, it response a tuple with {:ok, Tesla.Env} or {:error, reason}, and this are used to match the status of the connection.